### PR TITLE
allow registering an onReady callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The Boros TCF stub implements the [standard TCF v2 stub](https://github.com/Inte
 - Stubs the `window.__tcfapi` responding immediately to the commands
   - `ping` [See PingReturn in the stubbed __tcfapi](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#requirements-for-the-cmp-stub-api-script)
   - `pending` returns the pending calls accumulated while calling `window.__tcfapi` commands
+  - `onReady` returns the optional registered `onReady` callback
 
 - Initializes the cross-framee communication via `postMessagee`, [see usage details](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#how-can-vendors-that-use-iframes-call-the-cmp-api-from-an-iframe)
 
@@ -43,9 +44,22 @@ npm i @adv-ui/boros-tcf-stub --save
 import registerStub from '../main'
 
 // do your magic
-
 registerStub()
 ```
+
+**Register the Stub with an onReady callback**
+
+This allows creating additional commands that can have access to the Boros TCF API facade.
+
+```
+import registerStub from '../main'
+
+const onReady = api => initializeCustomCommands(api)
+ 
+registerStub({onReady})
+```
+
+> The `onReady` callback will be called after Boros TCF initializes the `window.__tcfapi` and before processing any pending command in the stub's queue.
 
 > Remember that the Stub **must** be registered before any script depending on the TCF is loaded
 
@@ -59,6 +73,8 @@ registerStub()
   async="false" 
 />
 ```
+
+> This does not accept registering an `onReady` callback. Import the `registerStub` and generate your own script if it's a need.
 
 ## License
 Boros TCF Stub is [MIT licensed](./LICENSE).

--- a/src/main/service/handler/TcfApiHandler.js
+++ b/src/main/service/handler/TcfApiHandler.js
@@ -1,7 +1,8 @@
 /* eslint-disable standard/no-callback-literal */
 export class TcfApiHandler {
-  constructor() {
+  constructor({onReady}) {
     this._queue = []
+    this._onReady = onReady
   }
 
   handle({command, version, callback, parameter}) {
@@ -19,6 +20,9 @@ export class TcfApiHandler {
       case PENDING_COMMAND: {
         return this._queue
       }
+      case ON_READY_COMMAND: {
+        return this._onReady
+      }
       default: {
         this._queue.push(() =>
           window.__tcfapi(command, version, callback, parameter)
@@ -31,3 +35,4 @@ export class TcfApiHandler {
 
 const PING_COMMAND = 'ping'
 const PENDING_COMMAND = 'pending'
+const ON_READY_COMMAND = 'onReady'

--- a/src/main/service/registerStub.js
+++ b/src/main/service/registerStub.js
@@ -2,7 +2,7 @@ import {registerTcfApiLocator} from './registerTcfApiLocator'
 import {registerIframeMessageHandler} from './registerIframeMessageHandler'
 import {registerTcfApiHandler} from './registerTcfApiHandler'
 
-export const registerStub = () => {
+export const registerStub = ({onReady} = {}) => {
   if (typeof window === 'undefined') {
     return
   }
@@ -10,5 +10,5 @@ export const registerStub = () => {
     return
   }
   registerIframeMessageHandler()
-  registerTcfApiHandler()
+  registerTcfApiHandler({onReady})
 }

--- a/src/main/service/registerTcfApiHandler.js
+++ b/src/main/service/registerTcfApiHandler.js
@@ -1,7 +1,7 @@
 import {TcfApiHandler} from './handler/TcfApiHandler'
 
-const tcfApiHandler = new TcfApiHandler()
-export const registerTcfApiHandler = () => {
+export const registerTcfApiHandler = ({onReady}) => {
+  const tcfApiHandler = new TcfApiHandler({onReady})
   window.__tcfapi = (command, version, callback, parameter) =>
     tcfApiHandler.handle({command, version, callback, parameter})
 }

--- a/src/test/indexTest.js
+++ b/src/test/indexTest.js
@@ -5,7 +5,7 @@ import {waitUntil} from '../main/service/waitUntil'
 
 describe('boros tcf stub', () => {
   beforeEach(() => {
-    jsdom(null, {runScripts: 'dangerously'})
+    jsdom()
     window.postMessage = message => {
       const event = new window.MessageEvent('message', {
         data: message,
@@ -34,6 +34,13 @@ describe('boros tcf stub', () => {
     window.__tcfapi('anyOtherCommand', 2, () => null)
     pending = window.__tcfapi('pending')
     expect(pending.length).to.equal(1)
+  })
+
+  it('should register an onReady function', done => {
+    registerStub({onReady: () => done()})
+    const onReady = window.__tcfapi('onReady')
+    expect(onReady).to.be.a('function')
+    onReady()
   })
 
   it('should accept iframe communications', () => {


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This allows registering an `onReady` callback before registering the stub in the window, in order to give access to the Boros TCF API facade and use it in customized commands if needed.

Example:

```
import registerStub from '../main'

const onReady = api => initializeCustomCommands(api)
 
registerStub({onReady})
```

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3286

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* The `onReady` callback will be called after Boros TCF initializes the `window.__tcfapi` and before processing any pending command in the stub's queue.

* calling `window.__tcfapi('onReady')` while Boros TCF is stubbed, will return the registered `onReady` callback

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/1it9hC7sf1yzsRff2M/giphy.gif)