### PR TITLE
avoid tcfapi collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/register": "7.8.0",
     "@babel/runtime": "7.8.0",
     "@s-ui/lint": "3",
-    "@s-ui/test": "2",
+    "@s-ui/test": "4",
     "babel-loader": "8.0.6",
     "babel-plugin-transform-define": "2.0.0",
     "babel-preset-sui": "3",
@@ -51,9 +51,8 @@
     "clean-webpack-plugin": "3.0.0",
     "codecov": "3.6.5",
     "html-webpack-plugin": "4.0.4",
-    "jsdom": "16.2.2",
+    "jsdom": "16.5.1",
     "jsdom-global": "3.0.2",
-    "mocha": "5.2.0",
     "nock": "12.0.3",
     "nyc": "15.0.0",
     "s3-folder-upload": "2.3.0",
@@ -71,6 +70,5 @@
   "prettier": "./node_modules/@s-ui/lint/.prettierrc.js",
   "stylelint": {
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/main/service/registerStub.js
+++ b/src/main/service/registerStub.js
@@ -6,6 +6,10 @@ export const registerStub = ({onReady} = {}) => {
   if (typeof window === 'undefined') {
     return
   }
+  if (window.__tcfapi) {
+    console.warn('[BorosTcf] attempted to register the stub twice')
+    return
+  }
   if (!registerTcfApiLocator()) {
     return
   }


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Avoid collision if a `window.__tcfapi` is already on page (a stub should not be included twice, so will warn about it)

